### PR TITLE
Add bs-json and shared folder for easier start

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -3,7 +3,7 @@
   "reason": {
     "react-jsx": 2
   },
-  "sources": ["src_client", "src_server"],
+  "sources": ["shared", "src_client", "src_server"],
   "package-specs": [
     {
       "module": "commonjs",
@@ -12,6 +12,6 @@
   ],
   "suffix": ".bs.js",
   "namespace": true,
-  "bs-dependencies": ["bs-express", "reason-react"],
+  "bs-dependencies": ["@glennsl/bs-json", "bs-express", "reason-react"],
   "refmt": 3
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@glennsl/bs-json": "^3.0.0",
     "bs-express": "^0.10.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/shared/Refdomains.re
+++ b/shared/Refdomains.re
@@ -1,0 +1,31 @@
+// Each refDomain object stored in the array of refdomains.json
+type t = {
+  refdomain: string, // The referring domain that contains at least one link to the target.
+  backlinks: int, // Number of backlinks found in the referring domain that link to the target.
+  refpages: int, // Number of referring pages found in the referring domain that link to the target.
+  firstSeen: string, // Least recent date when the Ahrefs crawler was able to visit the backlinks in the referring domain.
+  lastVisited: string, // Most recent date when the Ahrefs crawler was able to visit the backlinks in the referring domain.
+  domainRating: int // Domain Rating of the referring domain.
+};
+
+// The main type that represents the object stored in refdomains.json
+type main = {refDomains: array(t)};
+
+
+// Encoders
+
+let encodeOne = r => Obj.magic(r); // <---- Implement
+
+let encodeArray = arr => Obj.magic(arr); // <---- Implement
+
+let encodeMain = main =>
+  Json.Encode.(object_([("refdomains", encodeArray(main.refDomains))]));
+
+// Decoders
+
+let decodeOne = json => Obj.magic(json); // <---- Implement
+
+let decodeArray = json => Obj.magic(json); // <---- Implement
+
+let decodeMain = json =>
+  Json.Decode.{refDomains: json |> field("refdomains", decodeArray)};

--- a/shared/Refdomains.re
+++ b/shared/Refdomains.re
@@ -11,21 +11,20 @@ type t = {
 // The main type that represents the object stored in refdomains.json
 type main = {refDomains: array(t)};
 
-
 // Encoders
 
-let encodeOne = r => Obj.magic(r); // <---- Implement
+let encodeOne: t => Js.Json.t = r => Obj.magic(r); // <---- Implement
 
-let encodeArray = arr => Obj.magic(arr); // <---- Implement
+let encodeArray: array(t) => Js.Json.t = arr => Obj.magic(arr); // <---- Implement
 
 let encodeMain = main =>
   Json.Encode.(object_([("refdomains", encodeArray(main.refDomains))]));
 
 // Decoders
 
-let decodeOne = json => Obj.magic(json); // <---- Implement
+let decodeOne: Js.Json.t => t = json => Obj.magic(json); // <---- Implement
 
-let decodeArray = json => Obj.magic(json); // <---- Implement
+let decodeArray: Js.Json.t => array(t) = json => Obj.magic(json); // <---- Implement
 
 let decodeMain = json =>
   Json.Decode.{refDomains: json |> field("refdomains", decodeArray)};

--- a/src_client/RefdomainsTable.re
+++ b/src_client/RefdomainsTable.re
@@ -1,12 +1,17 @@
+let (catch, resolve, then_) = Js.Promise.(catch, resolve, then_);
+
 /* State declaration */
 type state =
-  | FetchedData
-  | Mounted
-  | NotInitialized;
+  | Init
+  | FetchingData
+  | Error
+  | DataReady(array(Refdomains.t));
 
 /* Action declaration */
 type action =
-  | FetchRefDomains;
+  | ComponentMounted
+  | DataFetched(array(Refdomains.t))
+  | DataFetchingFailed(Js.Promise.error);
 
 /* Component template declaration.
    Needs to be **after** state and action declarations! */
@@ -18,28 +23,55 @@ let make = _children => {
   /* spread the other default fields of component here and override a few */
   ...component,
 
-  didMount: self => self.send(FetchRefDomains),
-  initialState: () => NotInitialized,
+  didMount: self => self.send(ComponentMounted),
+
+  initialState: () => Init,
 
   /* State transitions */
   reducer: (action, _state) =>
     switch (action) {
-    | FetchRefDomains =>
-      Js.log(
-        "Component did mount. Fetching data from `localhost:8000/refdomains` could be added here.",
-      );
-      ReasonReact.Update(Mounted);
+    | ComponentMounted =>
+      ReasonReact.UpdateWithSideEffects(
+        FetchingData,
+        self =>
+          Window.fetch("http://localhost:8000/refdomains")
+          |> then_(response => response |> Window.json())
+          |> then_(json =>
+               json
+               |> Refdomains.decodeMain
+               |> (
+                 decoded =>
+                   self.send(DataFetched(decoded.refDomains)) |> resolve
+               )
+             )
+          |> catch(_error => {
+               Js.log(_error);
+               self.send(DataFetchingFailed(_error)) |> resolve;
+             })
+          |> ignore,
+      )
+    | DataFetchingFailed(err) =>
+      Js.log(err);
+      ReasonReact.Update(Error);
+    | DataFetched(json) => ReasonReact.Update(DataReady(json))
     },
 
-  render: _self => {
-    <table>
-      <thead>
-        <tr> <th> {s("Refdomain")} </th> <th> {s("Backlinks")} </th> </tr>
-      </thead>
-      <tbody>
-        <tr> <td> {s("foo.com")} </td> <td> {s("3")} </td> </tr>
-        <tr> <td> {s("bar.com")} </td> <td> {s("6")} </td> </tr>
-      </tbody>
-    </table>;
+  render: ({state}) => {
+    switch (state) {
+    | Init => <p> {s("Component ready")} </p>
+    | FetchingData => <p> {s("Fetching data...")} </p>
+    | Error =>
+      <p> {s("Error while loading data. Check the browser console.")} </p>
+    | DataReady(_refdomains) =>
+      <table>
+        <thead>
+          <tr> <th> {s("Refdomain")} </th> <th> {s("Backlinks")} </th> </tr>
+        </thead>
+        <tbody>
+          <tr> <td> {s("foo.com")} </td> <td> {s("3")} </td> </tr>
+          <tr> <td> {s("bar.com")} </td> <td> {s("6")} </td> </tr>
+        </tbody>
+      </table>
+    };
   },
 };

--- a/src_server/Server.re
+++ b/src_server/Server.re
@@ -9,7 +9,8 @@ let dirname =
 let getRefdomainsJson = () => {
   Node.Path.join([|dirname, "Refdomains.json"|])
   ->Node.Fs.readFileAsUtf8Sync
-  ->Js.Json.parseExn;
+  ->Js.Json.parseExn
+  ->Refdomains.decodeMain;
 };
 
 let app = express();
@@ -25,7 +26,9 @@ App.useOnPath(
 );
 
 App.get(app, ~path="/refdomains") @@
-Middleware.from((_next, _req) => Response.sendJson(getRefdomainsJson()));
+Middleware.from((_next, _req) =>
+  Response.sendJson(getRefdomainsJson()->Refdomains.encodeMain)
+);
 
 let onListen = err =>
   switch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@glennsl/bs-json@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@glennsl/bs-json/-/bs-json-3.0.0.tgz#b4e1cf6612270a8dd7287a8a71ebe17e8f0fb683"
+  integrity sha512-slqtGLd/c3yQK9Qfd1gfMB9JCzNU4wzCpVPfO9pXlG64M+te5r30FK++tb3uQEVlVLYtpgZ4wCHtkI8xoshgxQ==
+
 accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"


### PR DESCRIPTION
As the starter is right now in `master`, it involves a lot of work that is not really meaningful for the workshop (and can also be a distraction from its goals).

This PR adds `bs-json` and everything necessary so the attendants only have to write the encoders and decoders for the refDomains arrays and objects. I have left 4 functions implemented with `Obj.magic` that need to be replaced by the real code.